### PR TITLE
feat: Add generate both flag

### DIFF
--- a/src/main/java/org/web3j/gradle/plugin/GenerateContractWrapper.java
+++ b/src/main/java/org/web3j/gradle/plugin/GenerateContractWrapper.java
@@ -13,6 +13,9 @@
 package org.web3j.gradle.plugin;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.gradle.api.provider.Property;
 import org.gradle.workers.WorkAction;
@@ -28,22 +31,30 @@ public abstract class GenerateContractWrapper
         final String typesFlag =
                 getParameters().getUseNativeJavaTypes().get() ? "--javaTypes" : "--solidityTypes";
 
-        SolidityFunctionWrapperGenerator.main(
-                new String[] {
-                    "--abiFile",
-                    getParameters().getContractAbi().get().getAbsolutePath(),
-                    "--binFile",
-                    getParameters().getContractBin().get().getAbsolutePath(),
-                    "--outputDir",
-                    getParameters().getOutputDir().get(),
-                    "--package",
-                    getParameters().getPackageName().get(),
-                    "--contractName",
-                    getParameters().getContractName().get(),
-                    "--addressLength",
-                    String.valueOf(getParameters().getAddressLength().get()),
-                    typesFlag
-                });
+        final String generateBoth = getParameters().getGenerateBoth().get() ? "--generateBoth" : "";
+
+        List<String> arguments =
+                new ArrayList<>(
+                        Arrays.asList(
+                                "--abiFile",
+                                getParameters().getContractAbi().get().getAbsolutePath(),
+                                "--binFile",
+                                getParameters().getContractBin().get().getAbsolutePath(),
+                                "--outputDir",
+                                getParameters().getOutputDir().get(),
+                                "--package",
+                                getParameters().getPackageName().get(),
+                                "--contractName",
+                                getParameters().getContractName().get(),
+                                "--addressLength",
+                                String.valueOf(getParameters().getAddressLength().get()),
+                                typesFlag));
+
+        if (!generateBoth.isEmpty()) {
+            arguments.add(generateBoth);
+        }
+
+        SolidityFunctionWrapperGenerator.main(arguments.toArray(new String[0]));
     }
 
     public interface Parameters extends WorkParameters {
@@ -61,5 +72,7 @@ public abstract class GenerateContractWrapper
         Property<Integer> getAddressLength();
 
         Property<Boolean> getUseNativeJavaTypes();
+
+        Property<Boolean> getGenerateBoth();
     }
 }

--- a/src/main/java/org/web3j/gradle/plugin/GenerateContractWrappers.java
+++ b/src/main/java/org/web3j/gradle/plugin/GenerateContractWrappers.java
@@ -39,6 +39,8 @@ public class GenerateContractWrappers extends SourceTask {
 
     @Input @Optional private Integer addressLength;
 
+    @Input @Optional private Boolean generateBoth;
+
     @Inject
     public GenerateContractWrappers(final WorkerExecutor executor) {
         this.executor = executor;
@@ -72,6 +74,7 @@ public class GenerateContractWrappers extends SourceTask {
                                     params.getPackageName().set(packageName);
                                     params.getAddressLength().set(addressLength);
                                     params.getUseNativeJavaTypes().set(useNativeJavaTypes);
+                                    params.getGenerateBoth().set(generateBoth);
                                 });
             }
         }
@@ -124,5 +127,13 @@ public class GenerateContractWrappers extends SourceTask {
 
     public void setAddressLength(final Integer addressLength) {
         this.addressLength = addressLength;
+    }
+
+    public Boolean getGenerateBoth() {
+        return generateBoth;
+    }
+
+    public void setGenerateBoth(Boolean generateBoth) {
+        this.generateBoth = generateBoth;
     }
 }

--- a/src/main/java/org/web3j/gradle/plugin/Web3jExtension.java
+++ b/src/main/java/org/web3j/gradle/plugin/Web3jExtension.java
@@ -40,6 +40,8 @@ public class Web3jExtension {
     /** Generate smart contract wrappers using native Java types. */
     private Boolean useNativeJavaTypes;
 
+    private Boolean generateBoth;
+
     /** Excluded contract names from wrapper generation. */
     private List<String> excludedContracts;
 
@@ -73,6 +75,14 @@ public class Web3jExtension {
 
     public void setUseNativeJavaTypes(final Boolean useNativeJavaTypes) {
         this.useNativeJavaTypes = useNativeJavaTypes;
+    }
+
+    public Boolean getGenerateBoth() {
+        return generateBoth;
+    }
+
+    public void setGenerateBoth(Boolean generateBoth) {
+        this.generateBoth = generateBoth;
     }
 
     public List<String> getExcludedContracts() {
@@ -110,6 +120,7 @@ public class Web3jExtension {
         excludedContracts = new ArrayList<>();
         includedContracts = new ArrayList<>();
         addressBitLength = Address.DEFAULT_LENGTH / Byte.SIZE;
+        generateBoth = false;
     }
 
     protected String getDefaultGeneratedPackageName(Project project) {

--- a/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
+++ b/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
@@ -124,6 +124,7 @@ public class Web3jPlugin implements Plugin<Project> {
                                     task.setGeneratedJavaPackageName(
                                             extension.getGeneratedPackageName());
                                     task.setUseNativeJavaTypes(extension.getUseNativeJavaTypes());
+                                    task.setGenerateBoth(extension.getGenerateBoth());
                                     task.setGroup(Web3jExtension.NAME);
 
                                     // Set task excluded contracts


### PR DESCRIPTION
### What does this PR do?
This PR adds a **generateBoth** flag to the plugin. 
GenerateContractWrapper.java forwards parameters to SolidityFunctionWrapperGenerator in codegen which has an optional parameter **generateBoth**. This parameter is currently not exposed in the plugin so this pr aims to expose it.

### Where should the reviewer start?
`GenerateContractWrapper.java`

### Why is it needed?
We want to integrate the web3j-plugin in hedera-mirror-node integration tests and this flag will really help.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.